### PR TITLE
Minor editorial tweaks in README and updated test_simulator -> test_DynamicsPSL_nonauto_shapes_types to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ First clone the neuromancer, [slim](https://github.com/pnnl/slim), and [psl](htt
 
 ```bash
 
-user@machine:~$ git clone -b master https://github.com/pnnl/neuromancer.git --single-branch
-user@machine:~$ git clone -b master https://github.com/pnnl/psl.git --single-branch
-user@machine:~$ git clone -b master https://github.com/pnnl/slim.git --single-branch
+git clone -b master https://github.com/pnnl/neuromancer.git --single-branch
+git clone -b master https://github.com/pnnl/psl.git --single-branch
+git clone -b master https://github.com/pnnl/slim.git --single-branch
 
 ```
 ## Install dependencies
@@ -69,50 +69,50 @@ user@machine:~$ git clone -b master https://github.com/pnnl/slim.git --single-br
 ### Ubuntu
 
 ``` bash
-$ conda env create -f env.yml
-$ conda activate neuromancer
-(neuromancer) $ conda install tqdm
-(neuromancer) $ conda install pytorch-scatter -c pyg
-(neuromancer) $ conda install -c anaconda sphinx
-(neuromancer) $ conda install -c conda-forge sphinx_rtd_theme
+conda env create -f env.yml
+conda activate neuromancer
+conda install tqdm
+conda install pytorch-scatter -c pyg
+conda install -c anaconda sphinx
+conda install -c conda-forge sphinx_rtd_theme
 
 ```
 
 ### Windows
 
 ``` bash
-$ conda env create -f windows_env.yml
-$ conda activate neuromancer
-(neuromancer) $ conda install tqdm
-(neuromancer) $ conda install pytorch-scatter -c pyg
-(neuromancer) $ conda install -c anaconda sphinx
-(neuromancer) $ conda install -c conda-forge sphinx_rtd_theme
-(neuromancer) $ conda install -c defaults intel-openmp -f
+conda env create -f windows_env.yml
+conda activate neuromancer
+conda install tqdm
+conda install pytorch-scatter -c pyg
+conda install -c anaconda sphinx
+conda install -c conda-forge sphinx_rtd_theme
+conda install -c defaults intel-openmp -f
 ```
 
 ### Other operating system
 
 ``` bash
-$ conda create -n neuromancer python=3.10.4
-$ conda activate neuromancer
-(neuromancer) $ conda config --add channels conda-forge
-(neuromancer) $ conda install pytorch cudatoolkit=10.2 -c pytorch
-(neuromancer) $ conda install scipy numpy matplotlib scikit-learn pandas dill mlflow pydot=1.4.2 pyts numba networkx
-(neuromancer) $ conda install networkx plum-dispatch 
-(neuromancer) $ conda install -c anaconda pytest hypothesis
-(neuromancer) $ conda install cvxpy cvxopt casadi seaborn
-(neuromancer) $ conda install tqdm
-(neuromancer) $ conda install pytorch-scatter -c pyg
-(neuromancer) $ conda install -c anaconda sphinx
-(neuromancer) $ conda install -c conda-forge sphinx_rtd_theme
+conda create -n neuromancer python=3.10.4
+conda activate neuromancer
+conda config --add channels conda-forge
+conda install pytorch cudatoolkit=10.2 -c pytorch
+conda install scipy numpy matplotlib scikit-learn pandas dill mlflow pydot=1.4.2 pyts numba networkx
+conda install networkx plum-dispatch 
+conda install -c anaconda pytest hypothesis
+conda install cvxpy cvxopt casadi seaborn
+conda install tqdm
+conda install pytorch-scatter -c pyg
+conda install -c anaconda sphinx
+conda install -c conda-forge sphinx_rtd_theme
 
 ```
 
 ## Install neuromancer ecosystem
 ``` bash
-(neuromancer) $ cd psl; python setup.py develop
-(neuromancer) $ cd ../slim; python setup.py develop
-(neuromancer) $ cd ../neuromancer; python setup.py develop
+cd psl; python setup.py develop
+cd ../slim; python setup.py develop
+cd ../neuromancer; python setup.py develop
 ``` 
 
 ## Examples
@@ -125,8 +125,8 @@ The parametric programming examples have additional package dependencies for ben
 against traditional constrained optimization solvers, e.g., cvxpy (these should also have been installed using env.yml)
 
 ```console
-(neuromancer) user@machine:~$ conda install cvxpy cvxopt seaborn
-(neuromancer) user@machine:~$ pip install casadi 
+conda install cvxpy cvxopt seaborn
+pip install casadi 
 ```
 ## For developers
 All test code is developed using pytest and hypothesis. Please refer to 

--- a/neuromancer/simulator.py
+++ b/neuromancer/simulator.py
@@ -309,17 +309,13 @@ class DynamicsPSL(SystemDynamics):
             u = data[self.input_key_map['u']].reshape((1, -1))
         else:
             u = None
-        if 'Time' in self.input_key_map.keys():
-            Time = data[self.input_key_map['Time']]
-        else:
-            Time = None
         if 'd' in self.input_key_map.keys():
             d = data[self.input_key_map['d']]
-            out = self.model.simulate(nsim=1, U=u, D=d, x0=x0, Time=Time)
+            out = self.model.simulate(nsim=1, U=u, D=d, x0=x0)
         elif u is not None:
-            out = self.model.simulate(nsim=1, U=u, x0=x0, Time=Time)
+            out = self.model.simulate(nsim=1, U=u, x0=x0)
         else:
-            out = self.model.simulate(nsim=1, x0=x0, Time=Time)
+            out = self.model.simulate(nsim=1, x0=x0)
         output = {}
         output[self.output_keys[0]] = out['X'][1, :]
         if out['Y'].shape[0] == 1:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="neuromancer",
-    version=1.2.1,
+    version="1.2.1",
     description="Neural Modules with Adaptive Nonlinear Constraints and Efficient Regularization",
     url="https://pnnl.github.io/neuromancer/",
     author="Aaron Tuor, Jan Drgona, Mia Skomski, Stefan Dernbach, James Koch, Zhao Chen, Christian Møldrup Legaard, Draguna Vrabie",

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -73,13 +73,13 @@ def test_DynamicsPSL_ssm_shapes_types(system_name):
 def test_DynamicsPSL_nonauto_shapes_types(system):
     psl_model = system()
     sys = sim.DynamicsPSL(psl_model, input_key_map={'u': 'u'})
-    input_dict = {'x': np.random.randn(psl_model.nx),
-                  'u': np.random.randn(psl_model.nu)}
+    input_dict = {'x': abs(np.random.randn(psl_model.nx)),
+                  'u': abs(np.random.randn(psl_model.nu))}
     output_dict = sys.step(input_dict)
     assert isinstance(output_dict['x'], np.ndarray)
     assert isinstance(output_dict['y'], np.ndarray)
     assert output_dict['x'].shape == (psl_model.nx,)
-    assert output_dict['y'].shape == (psl_model.nx,)
+    assert output_dict['y'].shape == (psl_model.nx * 2,)
 
 
 @given(


### PR DESCRIPTION
Made minor changes to the formatting of the README to make it easier for people to copy and paste the commands into the terminal for setting up their conda environment.

The setup.py also needs to be stored as a string now that there are minor releases. Otherwise, floats would have been fine.

Updated test_simulator -> test_DynamicsPSL_nonauto_shapes_types to work. It looks like the output changed in psl -> nonautonomous.py that broke this test. In addition, the test case provided a standard deviation as test inputs, which can be negative,, but the two tank calculation uses "np.sqrt" that results in nan's appearing. I wrapped the test case inputs in abs() to prevent supplying negative values, but the psl repo should be updated to gracefully handle negative values and passing back nans.