### PR TITLE
fix issue with set_stats for building_envelope.py, set self.nsim befo…

### DIFF
--- a/src/neuromancer/psl/building_envelope.py
+++ b/src/neuromancer/psl/building_envelope.py
@@ -89,11 +89,11 @@ class BuildingEnvelope(ODE_NonAutonomous):
 
     def __init__(self, seed=59, exclude_norms=['Time'],
                  backend='numpy', requires_grad=False, system='Reno_full', set_stats=True):
+        self.nsim = 6000
         self.system = system
         download(self.url, self.path)
         super().__init__(seed=seed, exclude_norms=exclude_norms,
                          backend=backend, requires_grad=requires_grad, set_stats=set_stats)
-        self.nsim = 6000
 
     def get_xy(self):
         x0 = self.x0


### PR DESCRIPTION
…re super init

passes same number of psl tests (1012 passed)