### PR TITLE
Redundant or Incorrect Import Fixed

### DIFF
--- a/src/neuromancer/modules/gnn.py
+++ b/src/neuromancer/modules/gnn.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn as nn
-from neuromancer import integrators
+from neuromancer.dynamics import integrators
 import types
 
 

--- a/src/neuromancer/modules/solvers.py
+++ b/src/neuromancer/modules/solvers.py
@@ -2,7 +2,6 @@
 import torch
 import torch.nn as nn
 from neuromancer.gradients import gradient, jacobian
-from neuromancer.component import Component
 
 
 class GradientProjection(nn.Module):


### PR DESCRIPTION
As mentioned in #39, there are redundant or incorrect import statements in the code base. Specifically, the import issues were found in the following files:

* [solvers.py line 5](https://github.com/pnnl/neuromancer/blob/7e5e4c163a66367fe35bdc15bb39c4e1259d2afc/src/neuromancer/modules/solvers.py#L5) 
* [gnn.py line 3](https://github.com/pnnl/neuromancer/blob/7e5e4c163a66367fe35bdc15bb39c4e1259d2afc/src/neuromancer/modules/gnn.py#L3)

I've made the necessary corrections to resolve these import issues in this pull request. 