### PR TITLE
Update mlflow version in `pyproject.toml` requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "graphviz",
     "gymnasium==0.28.1",
     "matplotlib",
-    "mlflow",
+    "mlflow==2.5.0",
     "networkx==3.0.0",
     "numpy<1.24.0",
     "pandas",


### PR DESCRIPTION
Relevant issue(s): #57 , #60 , mlflow/mlflow#9331

Locking mlflow dependency at 2.5.0