### PR TITLE
change umax back to (0.5, 0.5) in TwoTank due to numerical instability issues

### DIFF
--- a/src/neuromancer/psl/nonautonomous.py
+++ b/src/neuromancer/psl/nonautonomous.py
@@ -168,7 +168,11 @@ class TwoTank(ODE):
 
     @property
     def umax(self):
-        return np.array([1.0, 1.0], dtype=np.float32)
+        """
+        Note that although the theoretical upper bound is 1.0,
+        this results in numerical instability in the integration.
+        """
+        return np.array([0.5, 0.5], dtype=np.float32)
 
     @cast_backend
     def get_x0(self):


### PR DESCRIPTION
Testing output:

umax [0.4 1. ]
bad=False

umax [0.5 1. ]
bad=False

umax [0.6 1. ]
.../scipy/integrate/_odepack_py.py:248: ODEintWarning: Excess work done on this call (perhaps wrong Dfun type). Run with full_output = 1 to get quantitative information.
  warnings.warn(warning_msg, ODEintWarning)
idx 88
Y [0.8107544 1.       ]
U [0.59733695 0.20365876]
idx 89
Y [180. 181.]
bad=True

umax [0.7 1. ]
idx 33
Y [0.03704964 1.        ]
U [0.66068655 0.8634035 ]
idx 34
Y [70. 71.]
bad=True

umax [0.8 1. ]
idx 45
Y [0.7856965 1.       ]
U [0.78013444 0.31302446]
idx 46
Y [94. 95.]
bad=True

umax [0.9 1. ]
idx 416
Y [0.13952523 1.        ]
U [0.53634316 0.6387195 ]
idx 417
Y [836. 837.]
bad=True

umax [1. 1.]
idx 370
Y [9.7292244e-11 9.2447508e-11]
U [0.55811936 0.1314565 ]
idx 371
Y [8.7887655e-11 1.0010000e+03]
bad=True


umax [0.5 0.5]
.../scipy/integrate/_odepack_py.py:248: ODEintWarning: Excess work done on this call (perhaps wrong Dfun type). Run with full_output = 1 to get quantitative information.
  warnings.warn(warning_msg, ODEintWarning)
bad=False

umax [0.5 0.7]
idx 326
Y [0.481472 1.      ]
U [0.49395072 0.34753278]
idx 327
Y [656. 657.]
bad=True

umax [0.5  0.99]
idx 324
Y [0.328987 1.      ]
U [0.49395072 0.4915107 ]
idx 325
Y [2.6120881e+17 2.7021601e+17]
bad=True

umax [0.5 1. ]
bad=False
Note: this was "luck", [0.5, 1.] does have observed numerical instability.