### PR TITLE
Add `freeze` and `unfreeze` Methods to `Node`, `System` and `Problem` Classes

### DIFF
--- a/src/neuromancer/problem.py
+++ b/src/neuromancer/problem.py
@@ -197,6 +197,20 @@ class Problem(nn.Module):
             fig.axes.get_yaxis().set_visible(False)
             plt.show()
 
+    def freeze(self):
+        """
+        Freezes the parameters of all nodes in the system
+        """
+        for node in self.nodes:
+            node.freeze()
+
+    def unfreeze(self):
+        """
+        Unfreezes the parameters of all nodes in the system
+        """
+        for node in self.nodes:
+            node.unfreeze()
+
     def __repr__(self):
         s = "### MODEL SUMMARY ###\n\nnodeS:"
         if len(self.nodes) > 0:

--- a/src/neuromancer/system.py
+++ b/src/neuromancer/system.py
@@ -52,6 +52,20 @@ class Node(nn.Module):
             output = [output]
         return {k: v for k, v in zip(self.output_keys, output)}
 
+    def freeze(self):
+        """
+        Freezes the parameters of the callable in this node
+        """
+        for param in self.callable.parameters():
+            param.requires_grad = False
+
+    def unfreeze(self):
+        """
+        Unfreezes the parameters of the callable in this node
+        """
+        for param in self.callable.parameters():
+            param.requires_grad = True
+
     def __repr__(self):
         return f"{self.name}({', '.join(self.input_keys)}) -> {', '.join(self.output_keys)}"
 
@@ -255,3 +269,17 @@ class System(nn.Module):
                 outdata = node(indata)  # compute
                 data = self.cat(data, outdata)  # feed the data nodes
         return data  # return recorded system measurements
+
+    def freeze(self):
+        """
+        Freezes the parameters of all nodes in the system
+        """
+        for node in self.nodes:
+            node.freeze()
+
+    def unfreeze(self):
+        """
+        Unfreezes the parameters of all nodes in the system
+        """
+        for node in self.nodes:
+            node.unfreeze()


### PR DESCRIPTION
This pull request introduces new methods, `freeze` and `unfreeze`, to the `Node`, `System`, and `Problem` classes. These methods allow users to easily freeze and unfreeze the parameters of all nodes within a System instance, facilitating more control over the training process.