### PR TITLE
Fix typos in intro tutorial docs

### DIFF
--- a/examples/tutorials/part_2_variable.ipynb
+++ b/examples/tutorials/part_2_variable.ipynb
@@ -80,7 +80,7 @@
     "Variables which will instantiate and perform the sequence of mathematical operations. PyTorch callables\n",
     "called with variables as inputs return variables. Variable supports binary infix operators (variable * variable, variable * numeric): +, -, *, @, **, <, <=, >, >=, ==, ^\n",
     "\n",
-    "There are several ways how to instantiate variable:"
+    "There are several ways to instantiate a variable:"
    ]
   },
   {
@@ -99,7 +99,7 @@
    ],
    "source": [
     "# 1, named Variable without trainable tensor value\n",
-    "#   intented to be used as a symbolic handler for input data or model outputs\n",
+    "#   intended to be used as a symbolic handler for input data or model outputs\n",
     "x1 = variable('x')\n",
     "# evaluate forward pass of the variable with dictionary input data\n",
     "print(x1({'x': 5.00}))"
@@ -335,7 +335,7 @@
    ],
    "source": [
     "# 5, composite Variable more complex example\n",
-    "a, b = variable('a'), variable('a')\n",
+    "a, b = variable('a'), variable('b')\n",
     "x6 = a/3. - 1.5*b**2 + 5\n",
     "# visualize computational graph of Variable\n",
     "x6.show()\n",
@@ -490,6 +490,7 @@
     "# 8, create new variables via slicing on existing variables\n",
     "# select column 0\n",
     "x10_column0 = x10[:, 0]\n",
+    "# note: the following still works because in case of a size mismatch the y tensor is automatically broadcast to the shape of the x tensor\n",
     "print(x10_column0({'x': torch.randn(2, 2), 'y': torch.randn(2, 1)}))\n",
     "x10_column0.show()"
    ]
@@ -521,6 +522,7 @@
    "source": [
     "# select column 1\n",
     "x10_column1 = x10[:, 1]\n",
+    "# as above, the y tensor is broadcast to the shape of the x tensor\n",
     "print(x10_column1({'x': torch.randn(2, 2), 'y': torch.randn(2, 1)}))\n",
     "x10_column1.show()"
    ]

--- a/examples/tutorials/part_2_variable.py
+++ b/examples/tutorials/part_2_variable.py
@@ -21,11 +21,11 @@ a Variable object is subjected to a comparison operator a Constraint is returned
 Variables which will instantiate and perform the sequence of mathematical operations. PyTorch callables
 called with variables as inputs return variables. Variable supports binary infix operators (variable * variable, variable * numeric): +, -, *, @, **, <, <=, >, >=, ==, ^
 
-There are several ways how to instantiate variable:
+There are several ways to instantiate a variable:
 """
 
 # 1, named Variable without trainable tensor value
-#   intented to be used as a symbolic handler for input data or model outputs
+#   intended to be used as a symbolic handler for input data or model outputs
 x1 = variable('x')
 # evaluate forward pass of the variable with dictionary input data
 print(x1({'x': 5.00}))
@@ -78,7 +78,7 @@ x6 = x1 + 5
 # visualize computational graph of Variable
 x6.show()
 # more complex example
-a, b = variable('a'), variable('a')
+a, b = variable('a'), variable('b')
 x6 = a/3. - 1.5*b**2 + 5
 x6.show()
 # evaluate forward pass of the variable with dictionary input data
@@ -110,10 +110,12 @@ print(x10({'x': 5.00, 'y': 5.00}))
 # 8, create new variables via slicing on existing variables
 # select column 0
 x10_column0 = x10[:, 0]
+# note: the following still works because in case of a size mismatch the y tensor is automatically broadcast to the shape of the x tensor
 print(x10_column0({'x': torch.randn(2, 2), 'y': torch.randn(2, 1)}))
 x10_column0.show()
 # select column 1
 x10_column1 = x10[:, 1]
+# as above, the y tensor is broadcast to the shape of the x tensor
 print(x10_column1({'x': torch.randn(2, 2), 'y': torch.randn(2, 1)}))
 x10_column1.show()
 

--- a/examples/tutorials/part_3_node.ipynb
+++ b/examples/tutorials/part_3_node.ipynb
@@ -270,7 +270,7 @@
     }
    ],
    "source": [
-    "# 2, instantiate recurrent neural net without bias, SVD linear map, and BLI activation\n",
+    "# 2, instantiate recurrent neural net without bias, SVD linear map, and BLU activation\n",
     "block_2 = blocks.RNN(insize=2, outsize=2,\n",
     "                  bias=False,\n",
     "                  linear_map=slim.linear.SVDLinear,\n",
@@ -346,7 +346,7 @@
     "# 1, create acyclic symbolic graph\n",
     "# list of nodes to construct the graph\n",
     "nodes = [node_1, node_2, node_3]\n",
-    "# 10 steps rollout\n",
+    "# n steps rollout\n",
     "nsteps = 3\n",
     "# connecting nodes via System class\n",
     "system_1 = System(nodes, nsteps=nsteps)\n",

--- a/examples/tutorials/part_3_node.py
+++ b/examples/tutorials/part_3_node.py
@@ -82,7 +82,7 @@ data = {'x3': torch.rand(10, 2)}
 print(node_4(data).keys())
 print(node_4(data)['y3'].shape)
 
-# 2, instantiate recurrent neural net without bias, SVD linear map, and BLI activation
+# 2, instantiate recurrent neural net without bias, SVD linear map, and BLU activation
 block_2 = blocks.RNN(insize=2, outsize=2,
                   bias=False,
                   linear_map=slim.linear.SVDLinear,
@@ -110,7 +110,7 @@ dynamical systems in open or closed loop rollouts by specifying number of steps 
 # 1, create acyclic symbolic graph
 # list of nodes to construct the graph
 nodes = [node_1, node_2, node_3]
-# 10 steps rollout
+# n steps rollout
 nsteps = 3
 # connecting nodes via System class
 system_1 = System(nodes, nsteps=nsteps)


### PR DESCRIPTION
## Changes Made
- **part_2_variable.ipynb** and **part_2_variable.py**:  
-- minor grammar change, 
-- fixed mistake in example 5 (variable x6) where one variable was not being used (a), and 
-- suggest commenting in example 8 when tensor sizes are mismatched for addition

-  **part_3_node.ipynb** and **part_3_node.py**:  
-- fixed two minor typos