### PR TITLE
Make tests run on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ conda install networkx=3.0 plum-dispatch=1.7.3
 conda install -c anaconda pytest hypothesis
 conda install cvxpy cvxopt casadi seaborn imageio
 conda install tqdm torchdiffeq toml
+conda install lightning wandb -c conda-forge
 ## (for Windows): conda install -c defaults intel-openmp -f
 ```
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -5,7 +5,7 @@ import torch
 
 
 
-@given(constraint_class = st.sampled_from[cn.LT, cn.EQ, cn.GT], device=st.sampled_from(['cpu', 'cuda:1']))
+@given(constraint_class = st.sampled_from([cn.LT, cn.Eq, cn.GT]), device=st.sampled_from(['cpu', 'cuda:1']))
 def test_constraint_device_placement(constraint_class, device):
     left_tensor = torch.tensor(10.)
     right_tensor = torch.tensor(7.)


### PR DESCRIPTION
Add 2 necessary packages (lightning, wandb) in manual installation section for linux. 

Fixed small typo and bug in test_constraint: 
1. sampled_from needs a list as argument. 
2. cn.EQ -> cn.Eq

Some tests still fail but at least pytest can now run in /test directory.