### PR TITLE
Fixing  lv equations in dynamics.ode and psl.autonomous

### DIFF
--- a/src/neuromancer/dynamics/ode.py
+++ b/src/neuromancer/dynamics/ode.py
@@ -287,7 +287,7 @@ class LotkaVolterraParam(ODESystem):
     def ode_equations(self, x):
         x1 = x[:, [0]]
         x2 = x[:, [-1]]
-        dx1 = 1.1 * x1 - 0.4*x1*x2
+        dx1 = self.alpha*x1 - 0.4*x1*x2
         dx2 = 0.1*x1*x2 - 0.4*x2
         return torch.cat([dx1, dx2], dim=-1)
 

--- a/src/neuromancer/dynamics/ode.py
+++ b/src/neuromancer/dynamics/ode.py
@@ -287,8 +287,8 @@ class LotkaVolterraParam(ODESystem):
     def ode_equations(self, x):
         x1 = x[:, [0]]
         x2 = x[:, [-1]]
-        dx1 = x1 - 0.1*x1*x2
-        dx2 = 1.5*x2 + 0.75*0.1*x1*x2
+        dx1 = 1.1 * x1 - 0.4*x1*x2
+        dx2 = 0.1*x1*x2 - 0.4*x2
         return torch.cat([dx1, dx2], dim=-1)
 
 

--- a/src/neuromancer/psl/autonomous.py
+++ b/src/neuromancer/psl/autonomous.py
@@ -190,17 +190,17 @@ class LotkaVolterra(ODE_Autonomous):
     def params(self):
         variables = {'x0': [5., 100.]}
         constants = {'ts': 0.1}
-        parameters = {'a': 1.,
-                      'b': 0.1,
-                      'c': 1.5,
-                      'd': 0.75,}
+        parameters = {'a': 1.1,
+                      'b': 0.4,
+                      'c': 0.1,
+                      'd': 0.4,}
         meta = {}
         return variables, constants, parameters, meta
 
     @cast_backend
     def equations(self, t, x):
         dx1 = self.a*x[0] - self.b*x[0]*x[1]
-        dx2 = -self.c*x[1] + self.d*self.b*x[0]*x[1]
+        dx2 = self.c**x[0]*x[1] - self.d*x[1]
         return [dx1, dx2]
 
 


### PR DESCRIPTION
Assuming the intention is for LV to be the predator-prey lokta volterra (https://en.wikipedia.org/wiki/Lotka%E2%80%93Volterra_equations) then i believe several of the defined equations are wrong. 

The old equations had a rogue negative sign and two of the parameters in the same term (which is not like the original equations). Also the params chosen by default are bit non standard so I switched them for the params got from fitting the famous lynx-hare system. So it provide a better baseline/easier to recognise bad fits for people coming from biology. 

to be clear old equations were:
```math
\dot{x} = \alpha x - \beta  x y
```
```math
\dot{y} = - \delta y + \gamma \beta x y
```

Whereas the correct equations are:
```math
\dot{x} = \alpha x - \beta  x y
```
```math
\dot{y} = \delta x y - \gamma y
```

The old params used were: $\alpha = 1, \beta = 0.1, \delta = 1.5, \gamma =0.75$

I have replaced those with the ones from https://en.wikipedia.org/wiki/Lotka%E2%80%93Volterra_equations (Heading: simple example): $\alpha = 1.1, \beta = 0.4, \delta = 0.1, \gamma =0.4$