### PR TITLE
Feature: Node accepts variables in addition to strings

### DIFF
--- a/src/neuromancer/system.py
+++ b/src/neuromancer/system.py
@@ -38,10 +38,10 @@ class Node(nn.Module):
         """
         super().__init__()
         self.input_keys = [
-            var.name if isinstance(var, Variable) else var for var in input_keys
+            var.key if isinstance(var, Variable) else var for var in input_keys
         ]
         self.output_keys = [
-            var.name if isinstance(var, Variable) else var for var in output_keys
+            var.key if isinstance(var, Variable) else var for var in output_keys
         ]
         self.callable, self.name = callable, name
 


### PR DESCRIPTION
At present, the Node class requires strings to describe the symbolic variables it uses as inputs and outputs. This PR allows Node to accept instantiated Variable objects as well. The change is backwards compatible but allows less house-keeping when renaming variables.