### PR TITLE
Fix missing index in CSTR.equations

### DIFF
--- a/src/neuromancer/psl/nonautonomous.py
+++ b/src/neuromancer/psl/nonautonomous.py
@@ -257,7 +257,7 @@ class CSTR(ODE):
             * Concentration of A in CSTR (mol/m^3)
             * Temperature in CSTR (K)
         """
-        Tc = u  # Temperature of cooling jacket (K)
+        Tc = u[0]  # Temperature of cooling jacket (K)
         Ca = x[0]  # Concentration of A in CSTR (mol/m^3)
         T = x[1]  # Temperature in CSTR (K)
         rA = self.k0 * self.B.core.exp(-self.EoverR / T) * Ca  # reaction rate

--- a/tests/psl/test_nonautonomous.py
+++ b/tests/psl/test_nonautonomous.py
@@ -1,0 +1,9 @@
+from neuromancer.psl.nonautonomous import CSTR
+
+
+def test_CSTR_instantiation():
+    """
+    Test instantiation of CSTR
+    """
+    modelSystem = CSTR()
+    modelSystem.simulate(nsim=2000)


### PR DESCRIPTION
I wasn't able to instantiate `neuromancer.psl.nonautonomous.CSTR` -- not even with default arguments; after some investigation, I found out that this is due to a missing index in the `CSTR.equations` method, which results in its output being 
```
>>> [dCadt, dTdt]
[1.2090975763656697e-07, array([1.101448], dtype=float32)]
```
and this mix of a scalar and rank 0 array causes issues later on `.cast` calls in the `cast_backend` decorator.

I think this PR would also solve https://github.com/pnnl/neuromancer/issues/229