### PR TITLE
fix: Update outdated neuromancer dependency in linux_env.yml

### DIFF
--- a/linux_env.yml
+++ b/linux_env.yml
@@ -305,5 +305,5 @@ dependencies:
   - zlib=1.2.12=h5eee18b_3
   - zstd=1.4.9=ha95c52a_0
   - pip:
-    - neuromancer==1.3.3
+    - neuromancer==1.5.4
 prefix: /home/tuor369/anaconda3/envs/neuromancer


### PR DESCRIPTION
Description:
This pull request addresses an installation error that occurs when setting up the environment using linux_env.yml.

The Problem
Currently, the conda env create -f linux_env.yml command fails with a Pip failed error. This is because the file pins neuromancer==1.3.3, a version that is no longer available on the Python Package Index (PyPI).

The Solution
This PR resolves the issue by updating the dependency to a recent, available version. The neuromancer pin has been changed from 1.3.3 to 1.5.4, specifically within the linux_env.yml file.