### PR TITLE
Fix #273: document pages empty

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../neuromancer'))
+sys.path.insert(0, os.path.abspath('../src'))
 
 
 # -- Project information -----------------------------------------------------


### PR DESCRIPTION
Closes #273

## Motivation

Sphinx was unable to autodoc the `neuromancer` package because `docs/conf.py` pointed `sys.path` at `../neuromancer` (a subdirectory that doesn't exist at that path), causing modules to silently fail to import and rendering documentation pages empty.

## Changes

**`docs/conf.py`, line 15:** Updated `sys.path.insert` to point at `../src` instead of `../neuromancer`, matching the actual package layout where the `neuromancer` source lives under `src/neuromancer/`.

```python
# Before
sys.path.insert(0, os.path.abspath('../neuromancer'))

# After
sys.path.insert(0, os.path.abspath('../src'))
```

## Testing

1. Built docs locally with `cd docs && make html` — all previously empty pages (e.g. `dynamics.html`, and others generated from `src/neuromancer/`) now render with full API content.
2. Confirmed no Sphinx `WARNING: autodoc: failed to import module` errors in the build output after the fix.
3. Verified the built `_build/html/dynamics.html` contains populated class and function documentation rather than an empty body.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*