### PR TITLE
Fix NameError in nd_walk when x0 is None and avoid_edge is False

### DIFF
--- a/src/neuromancer/psl/signals.py
+++ b/src/neuromancer/psl/signals.py
@@ -415,7 +415,7 @@ def nd_walk(nsim, d, min:_float_or_npd=0., max:_float_or_npd=1., x0:_float_or_np
         if avoid_edge:
             x0 = (umax-umin) * rng.random(size=(d,)) + umin
         else:
-            x0 = umin + (umax-umin)*rng.beta(a=alpha,b=beta,size=(d,))
+            x0 = umin + (umax-umin)*rng.beta(a=2,b=2,size=(d,))
     x0=np.full(d,x0, dtype=dtype)
     max_step = (umax-umin)/10 if max_step is None else \
         max_step

--- a/tests/psl/test_signals.py
+++ b/tests/psl/test_signals.py
@@ -1,6 +1,6 @@
 from hypothesis import given, settings, strategies as st
 import pytest
-from neuromancer.psl.signals import signals as sig
+from neuromancer.psl.signals import signals as sig, nd_walk
 import numpy as np
 
 signals = [v for k, v in sig.items()]
@@ -31,4 +31,16 @@ def test_signal_bound(signal, nsim, d, bound):
     assert not np.isnan(out).any()
     assert out.max() <= bound[1]
     assert out.min() >= bound[0]
+
+
+@pytest.mark.parametrize("avoid_edge", [True, False])
+def test_nd_walk_picks_start_when_x0_is_none(avoid_edge):
+    """
+    nd_walk should pick its own start for either edge setting. nd_walk is not
+    in the signals registry, so the parametrized tests above never reach it.
+    """
+    out = nd_walk(50, 3, min=-2., max=1.5, x0=None, avoid_edge=avoid_edge, rng=rng)
+    assert out.shape == (50, 3)
+    assert not np.isnan(out).any()
+    assert out.min() >= -2. and out.max() <= 1.5
 


### PR DESCRIPTION
In `psl/signals.py`, `nd_walk` crashes if you leave `x0` at its default and turn edge avoidance off:

```
>>> nd_walk(50, 3, min=-2., max=1.5, x0=None, avoid_edge=False)
NameError: name 'alpha' is not defined
```

The else branch that picks a random start uses `alpha` and `beta`, but neither is a parameter of `nd_walk` nor defined at module level. `avoid_edge` defaults to True and that branch is fine, which is presumably why nobody hit this.

I used `rng.beta(a=2, b=2, ...)`, the same frown-shaped default that `beta()` and `beta_walk_max_step` use elsewhere in the file, so the intended beta-distributed start is kept and the result stays inside [min, max].

`nd_walk` is not in the `signals` registry the parametrized tests iterate over, so I added a small case in `tests/psl/test_signals.py` covering `x0=None` for both `avoid_edge` values. The False case fails on master and passes with the change; the file is 16 passed after.

If you would rather the no-edge-avoidance path draw a uniform start instead of a beta one, say the word and I will switch it.