### PR TITLE
Make the System rollout linear in the horizon

### DIFF
--- a/benchmarks/bench_rollout.py
+++ b/benchmarks/bench_rollout.py
@@ -1,0 +1,221 @@
+"""
+Benchmark for the System rollout.
+
+Measures how `System.forward` scales with the rollout horizon, in three ways:
+
+  time       wall-clock for the rollout, and for rollout + backward
+  allocated  total bytes the rollout asks the allocator for, whether or not it keeps them
+  peak RSS   high-water resident memory of a rollout + backward
+
+The horizons double, so each column's scaling can be read straight off the table. Allocated
+bytes are worth watching independently of peak RSS -- memory that is freed immediately still
+costs time to zero and copy, and an allocator handed a long run of ever-larger requests cannot
+reuse the blocks it just freed, so churn shows up as resident memory even though nothing is
+retained.
+
+Nothing here reaches into the rollout's internals, so the same command is comparable across
+changes to how the rollout accumulates its output.
+
+Usage::
+
+    python benchmarks/bench_rollout.py                    # System, default horizons
+    python benchmarks/bench_rollout.py --preview          # SystemPreview instead
+    python benchmarks/bench_rollout.py --nsteps 100 200 400 --batch 64
+    python benchmarks/bench_rollout.py --no-memory        # timings only, much faster
+"""
+import argparse
+import multiprocessing
+import resource
+import time
+
+import torch
+from torch.profiler import ProfilerActivity, profile
+
+from neuromancer.modules import blocks
+from neuromancer.system import Node, System, SystemPreview
+
+# Single-zone building model dimensions, matching examples/domain_examples/building_control.py
+NX, NU, ND, NY = 4, 1, 3, 1
+
+
+def build_system(nsteps, preview=False):
+    """
+    Closed-loop building control system: disturbance observer -> neural policy -> linear state
+    space model -> output map, with the state fed back to the policy.
+
+    :param nsteps: (int) rollout horizon
+    :param preview: (bool) give the policy a past/future window of the comfort bounds, which
+                    exercises SystemPreview's windowed reads instead of single-step reads
+    :return: (System) closed-loop system
+    """
+    torch.manual_seed(0)
+    A = torch.eye(NX) + 0.01 * torch.randn(NX, NX)
+    # Scale to a spectral radius below 1. Left unstable, the closed-loop state reaches 1e13 by
+    # step 2000 and overflows to inf/nan by step 8000, which makes long horizons meaningless.
+    A = 0.99 * A / torch.linalg.eigvals(A).abs().max()
+    B = 0.1 * torch.randn(NX, NU)
+    C = torch.randn(NY, NX)
+    E = 0.1 * torch.randn(NX, ND)
+
+    window = {'past': 2, 'future': 2}
+    input_map = {'ymin': dict(window), 'ymax': dict(window)} if preview else None
+    span = window['past'] + 1 + window['future'] if preview else 1
+
+    net = blocks.MLP_bounds(insize=NY + 2 * NY * span + 2, outsize=NU, hsizes=[32, 32],
+                            min=torch.tensor([0.]), max=torch.tensor([5000.]))
+    nodes = [
+        Node(lambda d: d[:, :2], ['d'], ['d_obsv'], name='dist_obsv'),
+        Node(net, ['y', 'ymin', 'ymax', 'd_obsv'], ['u'], name='policy', input_map=input_map),
+        Node(lambda x, u, d: x @ A.T + u @ B.T + d @ E.T, ['x', 'u', 'd'], ['x'], name='SSM'),
+        Node(lambda x: x @ C.T, ['x'], ['y'], name='y=Cx'),
+    ]
+    system_class = SystemPreview if preview else System
+    return system_class(nodes, nsteps=nsteps, name='cl_system')
+
+
+def make_data(nsteps, batch):
+    """
+    One batch of training data: initial state, comfort bounds and disturbance trajectories.
+    """
+    torch.manual_seed(1)
+    x0 = torch.randn(batch, 1, NX)
+    ymin = 18.0 + torch.rand(batch, 1, NY) * torch.ones(batch, nsteps + 1, NY)
+    return {'x': x0, 'y': x0[:, :, [0]], 'ymin': ymin, 'ymax': ymin + 2.0,
+            'd': torch.randn(batch, nsteps + 1, ND)}
+
+
+def best_of(run, rounds=5, warmup=1):
+    """
+    Fastest of several timed runs. The minimum rather than the mean, because the noise here is
+    scheduler and allocator interference, which only ever adds time.
+
+    :param run: (callable) zero-argument callable to time
+    :return: (float) best wall-clock seconds observed
+    """
+    for _ in range(warmup):
+        run()
+    return min(_timed(run) for _ in range(rounds))
+
+
+def _timed(run):
+    start = time.perf_counter()
+    run()
+    return time.perf_counter() - start
+
+
+def bytes_allocated(run):
+    """
+    Total CPU bytes requested during run, summed over every allocating operation.
+
+    This is turnover, not occupancy: a rollout that builds its output by repeatedly growing
+    one tensor allocates far more than it ends up holding.
+
+    :param run: (callable) zero-argument callable to profile
+    :return: (int) bytes allocated
+    """
+    with profile(activities=[ProfilerActivity.CPU], profile_memory=True) as prof:
+        run()
+    return sum(e.cpu_memory_usage for e in prof.key_averages() if e.cpu_memory_usage > 0)
+
+
+def rollout_and_backward(system, data):
+    """
+    One rollout followed by a backward pass over it -- what a training step actually pays.
+
+    Autograd has to start from a scalar, and a rollout returns a dict of trajectories, so one
+    of them gets reduced. Which one is arbitrary: every output traces back through the whole
+    recurrence, so any choice walks the same graph. Substituting the mean, or an output other
+    than the control, or the sum of all of them, moves the measured cost by under half a
+    percent. Squared mean control effort is used because that is what a DPC objective
+    penalises, so the shape of the backward pass matches a real one.
+
+    Deliberately not a real Problem/PenaltyLoss: this benchmark isolates the rollout, and
+    building the loss machinery would put that on the clock too.
+
+    :param system: (System) closed-loop system to roll out
+    :param data: (dict {str: Tensor}) rollout inputs
+    """
+    system(data)['u'].square().mean().backward()
+
+
+def peak_rss_growth(nsteps, batch, preview):
+    """
+    Peak resident memory a rollout + backward adds on top of everything already loaded.
+
+    Reported as growth because the absolute figure is mostly the torch import. ru_maxrss is a
+    high-water mark that never falls, so this is only meaningful once per process: measured
+    in-process after a larger horizon it reads zero. run spawns a fresh process per call.
+
+    :return: (float) megabytes
+    """
+    system = build_system(nsteps, preview)
+    data = make_data(nsteps, batch)
+    before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    rollout_and_backward(system, data)
+    after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return (after - before) / (1024 * 1024)
+
+
+def measure(nsteps, batch, preview):
+    """
+    Time and allocation for one horizon.
+
+    :return: (dict) forward seconds, forward+backward seconds, bytes allocated by the forward
+    """
+    system = build_system(nsteps, preview)
+    data = make_data(nsteps, batch)
+
+    def forward():
+        with torch.no_grad():
+            system(data)
+
+    def forward_backward():
+        rollout_and_backward(system, data)
+
+    return {'fwd': best_of(forward),
+            'fwd_bwd': best_of(forward_backward, rounds=3),
+            'allocated': bytes_allocated(forward)}
+
+
+def run(horizons, batch, preview, with_memory):
+    """Measures every horizon and prints the table."""
+    rows = [measure(n, batch, preview) for n in horizons]
+    if with_memory:
+        spawn = multiprocessing.get_context('spawn')
+        for nsteps, row in zip(horizons, rows):
+            # one fresh process per horizon, see peak_rss_growth
+            with spawn.Pool(1, initializer=torch.set_num_threads, initargs=(1,)) as pool:
+                row['rss'] = pool.apply(peak_rss_growth, (nsteps, batch, preview))
+
+    label = 'SystemPreview' if preview else 'System'
+    print(f'\n{label}.forward, batch={batch}\n')
+    header = f"{'nsteps':>7}{'fwd ms':>12}{'fwd+bwd ms':>14}{'allocated MB':>16}"
+    if with_memory:
+        header += f"{'peak RSS MB':>14}"
+    print(header)
+    print('-' * len(header))
+    for nsteps, row in zip(horizons, rows):
+        line = (f"{nsteps:>7}{row['fwd'] * 1e3:>12.2f}{row['fwd_bwd'] * 1e3:>14.2f}"
+                f"{row['allocated'] / 1e6:>16.1f}")
+        if with_memory:
+            line += f"{row['rss']:>14.1f}"
+        print(line)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--nsteps', nargs='+', type=int, default=[250, 500, 1000, 2000],
+                        help='rollout horizons; doubling them makes the scaling readable')
+    parser.add_argument('--batch', type=int, default=100)
+    parser.add_argument('--preview', action='store_true',
+                        help='benchmark SystemPreview instead of System')
+    parser.add_argument('--no-memory', action='store_true',
+                        help='skip peak RSS, which spawns a process per horizon')
+    args = parser.parse_args()
+
+    torch.set_num_threads(1)
+    run(args.nsteps, args.batch, args.preview, not args.no_memory)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/neuromancer/system.py
+++ b/src/neuromancer/system.py
@@ -131,6 +131,63 @@ class MovingHorizon(nn.Module):
         return self.module(inputs)
 
 
+class RolloutBuffers:
+    """
+    Rollout data for a System, holding each key as a list of per-step (batch, dim) tensors
+    rather than as one (batch, time, dim) tensor that grows a step at a time.
+
+    The rollout reads `rollout[key][i]` and feeds node outputs back with `append`, exactly as
+    it read `data[key][:, i]` and fed back with `cat`. The difference is what a write costs:
+    appending to a list is O(1), while concatenating onto a 3-d tensor reallocates and copies
+    every step accumulated so far. `collapse` stacks the buffers back into 3-d tensors once,
+    at the end.
+
+    Reads stay index-based, which is what keeps this equivalent to the original: within a
+    step, index `i` of a key may refer either to data the caller supplied or to a value a node
+    appended on step `i-1`, and a node must see whichever the old code would have shown it.
+    """
+    def __init__(self, data, keys):
+        """
+        :param data: (dict {str: Tensor}) Rollout inputs, shapes assumed (batch, time, dim)
+        :param keys: (iterable of str) Keys the nodes read or write. Any of these present in
+                     data are unbound into per-step views; everything else passes through
+                     collapse untouched.
+        """
+        self.data = data
+        self.steps = {k: list(torch.unbind(data[k], dim=1)) for k in keys if k in data}
+        self.written = set()
+
+    def __getitem__(self, key):
+        """
+        :param key: (str) Data key
+        :return: (list of Tensor) Per-step (batch, dim) tensors recorded so far for key
+        """
+        return self.steps[key]
+
+    def append(self, outputs):
+        """
+        Records one step of node outputs.
+
+        :param outputs: (dict {str: Tensor}) Output of a node, shape (batch, dim)
+        """
+        for key, value in outputs.items():
+            if key in self.steps:
+                self.steps[key].append(value)
+            else:
+                self.steps[key] = [value]
+            self.written.add(key)
+
+    def collapse(self):
+        """
+        Stacks the per-step buffers back into 3-d tensors.
+
+        :return: (dict {str: Tensor}) The input data with every key a node wrote replaced by
+                 its (batch, time, dim) rollout. The caller's dict is not mutated.
+        """
+        stacked = {k: torch.stack(self.steps[k], dim=1) for k in self.written}
+        return {**self.data, **stacked}
+
+
 class System(nn.Module):
     """
     Simple implementation for arbitrary cyclic computation
@@ -152,6 +209,7 @@ class System(nn.Module):
             self.init = init_func
         self.input_keys = set().union(*[c.input_keys for c in nodes])
         self.output_keys = set().union(*[c.output_keys for c in nodes])
+        self.rollout_keys = self.input_keys | self.output_keys  # every key the rollout touches
         self.system_graph = self.graph()
 
     def graph(self):
@@ -289,15 +347,17 @@ class System(nn.Module):
                                            have 3 dims.
         :return: (dict: {str: Tensor}) data with outputs of nstep rollout of Node interactions
         """
+        # Ensures that System never adds keys to the input_dict
         data = input_dict.copy()
         nsteps = self.nsteps if self.nsteps is not None else data[self.nstep_key].shape[1]  # Infer number of rollout steps
         data = self.init(data)  # Set initial conditions of the system
+        rollout = RolloutBuffers(data, self.rollout_keys)
         for i in range(nsteps):
             for node in self.nodes:
-                indata = {k: data[k][:, i] for k in node.input_keys}  # collect what the compute node needs from data nodes
+                indata = {k: rollout[k][i] for k in node.input_keys}  # collect what the compute node needs from data nodes
                 outdata = node(indata)  # compute
-                data = self.cat(data, outdata)  # feed the data nodes
-        return data  # return recorded system measurements
+                rollout.append(outdata)  # feed the data nodes
+        return rollout.collapse()  # return recorded system measurements
 
     def freeze(self):
         """
@@ -342,6 +402,53 @@ class SystemPreview(System):
 
         self.start_iter = start_iter
 
+    def window_indices(self, iteration, length, input_map):
+        """
+        Indices of the preview window [iteration - past, iteration + future] (inclusive),
+        remapped into [0, length - 1] according to the padding mode.
+
+        :param iteration: (int) Current timestep (0-indexed).
+        :param length: (int) Number of timesteps available.
+        :param input_map: (dict) Window configuration, see get_mapped_data.
+        :return: (list of int, list of bool or None) Window indices, plus out-of-bounds
+                 flags for "constant" padding (None for every other padding mode).
+        """
+        if not (('past' in input_map) and ('future' in input_map)):
+            raise ValueError(
+                "Mapping must be dict w/ at least 'past' and 'future' keys")
+
+        past, future = input_map['past'], input_map['future']
+
+        if (past < 0) or (future < 0):
+            raise ValueError("(past,future) in mapping must be non-negative")
+
+        # Get padding mode, default to nearest if none is specified
+        pad_mode = input_map.get('pad_mode', 'nearest').lower()
+        window = range(iteration - past, iteration + future + 1)
+
+        if pad_mode == "nearest":
+            return [min(max(i, 0), length - 1) for i in window], None
+
+        if (pad_mode == "cyclic") or (pad_mode == "circular"):
+            return [i % length for i in window], None
+
+        if pad_mode == "reflect":
+            if length == 1:
+                return [0 for _ in window], None
+            period = 2 * (length - 1)
+            return [period - i % period if i % period >= length else i % period
+                    for i in window], None
+
+        if pad_mode == "constant":
+            out_of_bounds = [(i < 0) or (i >= length) for i in window]
+            # clamp to make the gather safe, the out-of-bounds entries get overwritten
+            return [min(max(i, 0), length - 1) for i in window], out_of_bounds
+
+        raise ValueError(
+            f"Unknown padding mode '{pad_mode}'. "
+            "Supported: 'nearest', 'cyclic', 'reflect', 'constant'."
+        )
+
     def get_mapped_data(self, data, iteration, input_map):
         """
         Extracts a temporal slice of data for a given variable with a preview window.
@@ -363,62 +470,43 @@ class SystemPreview(System):
         Keys not present in this dict will receive only the current timestep.
         :return: (Tensor) Shape (batch, dim * (past + 1 + future)).
         """
-
-        if not (('past' in input_map) and ('future' in input_map)):
-            raise ValueError(
-                "Mapping must be dict w/ at least 'past' and 'future' keys")
-
-        past, future = input_map['past'], input_map['future']
-
-        # Get padding mode, default to nearest if none is specified
-        pad_mode = input_map.get('pad_mode', 'nearest').lower()
-
-        batch, T, dim = data.shape
-
-        if (past < 0) or (future < 0):
-            raise ValueError("(past,future) in mapping must be non-negative")
-
-        # -- build every index we need in one shot --
-        indices = torch.arange(
-            iteration - past, iteration + future + 1, device=data.device
-        )
-
-        # -- remap out-of-bounds indices (all vectorised) --
-        if pad_mode == "nearest":
-            indices = indices.clamp(0, T - 1)
-
-        elif (pad_mode == "cyclic") or (pad_mode == "circular"):
-            indices = indices % T
-
-        elif pad_mode == "reflect":
-            if T == 1:
-                indices = torch.zeros_like(indices)
-            else:
-                period = 2 * (T - 1)
-                indices = indices % period
-                indices = torch.where(indices >= T, period - indices, indices)
-
-        elif pad_mode == "constant":
-            # get fill value if constant is specified, default to zero
-            fill = input_map.get("fill", 0)
-            oob = (indices < 0) | (indices >= T)
-            indices = indices.clamp(0, T - 1)        # make safe for gather
-
-        else:
-            raise ValueError(
-                f"Unknown padding mode '{pad_mode}'. "
-                "Supported: 'nearest', 'cyclic', 'reflect', 'constant'."
-            )
+        indices, out_of_bounds = self.window_indices(
+            iteration, data.shape[1], input_map)
 
         # -- single advanced-index gather: (batch, window, dim) --
         gathered = data[:, indices, :]
 
         # -- mask after the fact for constant padding --
-        if pad_mode == "constant":
-            gathered = gathered.masked_fill(oob[None, :, None], fill)
+        if out_of_bounds is not None:
+            mask = torch.tensor(out_of_bounds, device=data.device)
+            gathered = gathered.masked_fill(
+                mask[None, :, None], input_map.get("fill", 0))
 
         # -- flatten window into feature dim --
-        return gathered.reshape(batch, -1)
+        return gathered.reshape(data.shape[0], -1)
+
+    def get_mapped_steps(self, steps, iteration, input_map):
+        """
+        Same preview window as get_mapped_data, gathered from the rollout data.
+
+        This is what the rollout uses, since RolloutBuffers holds each key as a list of
+        per-step tensors rather than as a 3-d tensor.
+
+        :param steps: (list of Tensor) Per-step tensors of shape (batch, dim).
+        :param iteration: (int) Current timestep (0-indexed).
+        :param input_map: (dict) Window configuration, see get_mapped_data.
+        :return: (Tensor) Shape (batch, dim * (past + 1 + future)).
+        """
+        indices, out_of_bounds = self.window_indices(
+            iteration, len(steps), input_map)
+        window = [steps[i] for i in indices]
+
+        if out_of_bounds is not None:
+            fill = input_map.get("fill", 0)
+            window = [torch.full_like(step, fill) if is_oob else step
+                      for step, is_oob in zip(window, out_of_bounds)]
+
+        return torch.cat(window, dim=-1)
 
     def forward(self, input_dict):
         """
@@ -428,6 +516,7 @@ class SystemPreview(System):
             tensors have 3 dims.
         :return: (dict: {str: Tensor}) data with outputs of nstep rollout of Node interactions
         """
+        # Ensures that System never adds keys to the input_dict
         data = input_dict.copy()
 
         # Infer number of rollout steps
@@ -437,13 +526,14 @@ class SystemPreview(System):
         )
 
         data = self.init(data)  # Set initial conditions of the system
+        rollout = RolloutBuffers(data, self.rollout_keys)
         for i in range(self.start_iter, self.start_iter + nsteps):
             for node in self.nodes:
                 indata = {
                     k: (
-                        data[k][:, i] if k not in node.input_map
-                        else self.get_mapped_data(
-                            data=data[k],
+                        rollout[k][i] if k not in node.input_map
+                        else self.get_mapped_steps(
+                            steps=rollout[k],
                             iteration=i,
                             input_map=node.input_map[k]
                         )
@@ -451,5 +541,5 @@ class SystemPreview(System):
                 }  # collect what the compute node needs from data nodes
 
                 outdata = node(indata)  # compute
-                data = self.cat(data, outdata)  # feed the data nodes
-        return data  # return recorded system measurements
+                rollout.append(outdata)  # feed the data nodes
+        return rollout.collapse()  # return recorded system measurements

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -756,6 +756,113 @@ def test_system_preview_start_iter():
         assert torch.allclose(result['y1'][:, t], 2.0 * data['x1'][:, start + t])
 
 
+"""
+############ TESTING THE BUFFERED ROLLOUT AGAINST THE ORIGINAL cat ROLLOUT ############
+"""
+def reference_rollout(system, input_dict):
+    """
+    The rollout as it was before RolloutBuffers: every key is a 3-d tensor that System.cat
+    grows by one step per node output. forward now accumulates per-step tensors and stacks
+    once at the end, and must agree with this exactly, gradients included.
+
+    Serves both System and SystemPreview: for System every node's input_map is empty and
+    there is no start_iter, so the preview branches are simply never taken.
+    """
+    data = system.init(input_dict.copy())
+    start = getattr(system, 'start_iter', 0)
+    nsteps = system.nsteps if system.nsteps is not None else data[system.nstep_key].shape[1] - start
+    for i in range(start, start + nsteps):
+        for node in system.nodes:
+            indata = {k: (system.get_mapped_data(data[k], i, node.input_map[k])
+                          if k in node.input_map else data[k][:, i])
+                      for k in node.input_keys}
+            data = system.cat(data, node(indata))
+    return data
+
+
+def closed_loop_system(nsteps, system_class=System, input_map=None, **kwargs):
+    """Closed loop with feedback: policy -> dynamics -> observation, x fed back to the policy."""
+    torch.manual_seed(0)
+    window = 1 if input_map is None else input_map['d']['past'] + 1 + input_map['d']['future']
+    policy_net = nn.Linear(4 + 3 * window, 2)
+    dynamics_net = nn.Linear(4 + 2, 4)
+    nodes = [
+        Node(lambda x, d: policy_net(torch.cat([x, d], dim=-1)), ['x', 'd'], ['u'],
+             name='policy', input_map=input_map),
+        Node(lambda x, u: dynamics_net(torch.cat([x, u], dim=-1)), ['x', 'u'], ['x'],
+             name='dynamics'),
+        Node(lambda x: x[:, :1], ['x'], ['y'], name='observation'),
+    ]
+    return system_class(nodes, nsteps=nsteps, **kwargs)
+
+
+@pytest.mark.parametrize('nsteps', [0, 1, 5, 20])
+def test_system_forward_matches_reference_rollout(nsteps):
+    """The buffered rollout is bit-identical to growing the tensors with cat."""
+    system = closed_loop_system(nsteps)
+    data = {'x': torch.rand(3, 1, 4), 'd': torch.rand(3, max(nsteps, 1), 3)}
+    assert dict_equals(system(dict(data)), reference_rollout(system, dict(data)))
+
+
+def test_system_forward_matches_reference_when_output_key_is_also_input_data():
+    """A key given as full input data and also written by a node keeps the append semantics."""
+    system = closed_loop_system(5)
+    data = {'x': torch.rand(3, 1, 4), 'd': torch.rand(3, 5, 3), 'y': torch.rand(3, 5, 1)}
+    assert dict_equals(system(dict(data)), reference_rollout(system, dict(data)))
+
+
+def test_system_forward_does_not_mutate_the_callers_dict():
+    """collapse returns a new dict rather than writing rollout outputs back into the input."""
+    system = closed_loop_system(5)
+    data = {'x': torch.rand(3, 1, 4), 'd': torch.rand(3, 5, 3)}
+    system(data)
+    assert set(data) == {'x', 'd'}
+    assert data['x'].shape == (3, 1, 4)
+
+
+@pytest.mark.parametrize('pad_mode', ['nearest', 'cyclic', 'reflect', 'constant'])
+@pytest.mark.parametrize('past,future', [(0, 0), (2, 0), (0, 2), (2, 3)])
+def test_preview_forward_matches_reference_rollout(pad_mode, past, future):
+    """The full SystemPreview rollout agrees with the reference for every padding mode."""
+    input_map = {'d': {'past': past, 'future': future, 'pad_mode': pad_mode, 'fill': -1.0}}
+    system = closed_loop_system(6, system_class=SystemPreview, input_map=input_map)
+    data = {'x': torch.rand(3, 1, 4), 'd': torch.rand(3, 6, 3)}
+    assert dict_equals(system(dict(data)), reference_rollout(system, dict(data)))
+
+
+@pytest.mark.parametrize('system_class', [System, SystemPreview])
+def test_system_forward_gradients_match_reference_rollout(system_class):
+    """Backward through the stacked outputs gives the same parameter gradients."""
+    input_map = {'d': {'past': 1, 'future': 1}} if system_class is SystemPreview else None
+    system = closed_loop_system(8, system_class=system_class, input_map=input_map)
+    data = {'x': torch.rand(3, 1, 4), 'd': torch.rand(3, 8, 3)}
+
+    grads = []
+    for rollout in [system, lambda d: reference_rollout(system, d)]:
+        system.zero_grad()
+        rollout(dict(data))['y'].square().sum().backward()
+        grads.append([p.grad.clone() for p in system.parameters()])
+
+    for buffered, reference in zip(*grads):
+        assert torch.equal(buffered, reference)
+
+
+@pytest.mark.parametrize('pad_mode', ['nearest', 'cyclic', 'reflect', 'constant'])
+@pytest.mark.parametrize('past,future', [(0, 0), (2, 0), (0, 2), (2, 3)])
+def test_get_mapped_steps_matches_get_mapped_data(pad_mode, past, future):
+    """
+    get_mapped_steps reads the same window from the rollout buffers that get_mapped_data
+    reads from a 3-d tensor.
+    """
+    input_map = {'d': {'past': past, 'future': future, 'pad_mode': pad_mode, 'fill': -1.0}}
+    system = closed_loop_system(6, system_class=SystemPreview, input_map=input_map)
+    data = torch.rand(3, 6, 3)
+    for iteration in range(6):
+        assert torch.allclose(
+            system.get_mapped_steps(list(torch.unbind(data, dim=1)), iteration, input_map['d']),
+            system.get_mapped_data(data, iteration, input_map['d']))
+
+
 def test_system_preview_nsteps_inferred_with_start_iter():
     """When nsteps is not given, it is inferred as T - start_iter from the nstep_key tensor."""
     start, T, batch = 2, 6, 2


### PR DESCRIPTION
The core of the system class, the forward method, grows its output tensor using torch.cat once per node step which reallocates and copies every step accumulated so far. This makes a rollout O(n^2) in both time and memory allocation.

The rollout now accumulates per-step in a list of "RolloutBuffers" (just a list of tensor outputs per step) and is collapsed once at the end of the rollout. Reads stay index-based, so feedback loops and keys that are both supplied and written behave exactly as before. The loop in forward is three lines different from the original (with the addition of a rollout buffer class which hides the magic). 

To test on your machine, check out the first commit on this branch and run the included system benchmark to see the time / memory usage of the torch.cat method. Then check out the second commit and run the same benchmark to see the updated run time / memory usage. Finally, run the new tests to see the identical behavior tests.

Also included test for ensuring the output is bit identical, the gradients are identical, and system class does not modify data dict passed in.